### PR TITLE
Cleaner ofxHardwareDriver shutdown

### DIFF
--- a/src/ofxHardwareDriver.cpp
+++ b/src/ofxHardwareDriver.cpp
@@ -10,7 +10,7 @@ ofxHardwareDriver::~ofxHardwareDriver() {
 
 void ofxHardwareDriver::setup(int index)
 {
-	libusb_context *ctx;
+	//libusb_context *ctx;
 	libusb_init(&ctx);
 	libusb_device **devs; //pointer to pointer of device, used to retrieve a list of devices
 	ssize_t cnt = libusb_get_device_list (ctx, &devs); //get the list of devices
@@ -135,5 +135,5 @@ void ofxHardwareDriver::shutDown() {
 						// strange behaviour if the kinect is tilted in between 
 						// application starts eg., the angle continues to be set 
 						// even when app not running...which is odd...
-	libusb_exit(0);
+	libusb_exit(ctx);
 }

--- a/src/ofxHardwareDriver.h
+++ b/src/ofxHardwareDriver.h
@@ -67,6 +67,8 @@ public:
 	int		tilt_angle;
 	
 	void shutDown();
+    
+    libusb_context *ctx;
 	
 private:
 	

--- a/src/ofxTrackedUser.h
+++ b/src/ofxTrackedUser.h
@@ -75,7 +75,9 @@ public:
 	ofxLimb hip;
 	XnUserID id;
 
-
+    bool skeletonTracking, skeletonCalibrating, skeletonCalibrated;
+    XnPoint3D	center;
+    
 private:
 
 	ofxTrackedUser(ofxOpenNIContext* pContext);

--- a/src/ofxUserGenerator.cpp
+++ b/src/ofxUserGenerator.cpp
@@ -282,7 +282,11 @@ void ofxUserGenerator::update() {
 	for(int i = 0; i < found_users; ++i) {
 		if(user_generator.GetSkeletonCap().IsTracking(users[i])) {	
 			tracked_users[i]->id = users[i];
-			tracked_users[i]->updateBonePositions();
+			user_generator.GetCoM(users[i], tracked_users[i]->center);
+            tracked_users[i]->skeletonTracking	  = user_generator.GetSkeletonCap().IsTracking(users[i]);
+            tracked_users[i]->skeletonCalibrating = user_generator.GetSkeletonCap().IsCalibrating(users[i]);
+            tracked_users[i]->skeletonCalibrated  = user_generator.GetSkeletonCap().IsCalibrated(users[i]);
+            if(tracked_users[i]->skeletonTracking) tracked_users[i]->updateBonePositions();
 		}
 	}
 	


### PR DESCRIPTION
This fix from the forum stops errors on quit:
http://forum.openframeworks.cc/index.php/topic,5125.165.html

before this I would have to hide to the errors with the command:
defaults write com.apple.CrashReporter DialogType none
