### PR TITLE
Implement interfaces ofBaseVideo and ofxBase3DVideo

### DIFF
--- a/src/ofxBase3DVideo.h
+++ b/src/ofxBase3DVideo.h
@@ -1,0 +1,41 @@
+/*==============================================================================
+
+    Copyright (c) 2010, 2011 ofxKinect Team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+    
+==============================================================================*/
+#pragma once
+
+/// \class ofxBase3DVideo
+///
+/// a base class for 3D video devices
+class ofxBase3DVideo: public ofBaseVideo {
+
+public:
+    
+    /// get the pixels of the most recent depth frame
+    virtual unsigned char* getDepthPixels()=0;
+    
+    /// get the distance in millimeters to a given point as a float array
+    virtual float* getDistancePixels()=0;
+    
+    /// get the grayscale depth texture
+    virtual ofTexture& getDepthTextureReference()=0;
+};

--- a/src/ofxOpenNI.h
+++ b/src/ofxOpenNI.h
@@ -42,9 +42,11 @@ static int instanceCount = -1;
 #include "ofxOpenNITypes.h"
 #include "ofxOpenNIUtils.h"
 
+#include "ofxBase3DVideo.h"
+
 using namespace xn;
 
-class ofxOpenNI : public ofThread {
+class ofxOpenNI : public ofThread, public ofxBase3DVideo {
 
 public:
 
@@ -270,7 +272,7 @@ public:
 	void setSync(bool b);
     bool getSync();
 
-	ofPixels& getDepthPixels();
+	ofPixels& getDepthPixelsRef();
 	ofShortPixels& getDepthRawPixels();
 	ofPixels& getImagePixels();
 
@@ -309,6 +311,19 @@ public:
     ofEvent<ofxOpenNIUserEvent> userEvent;
     ofEvent<ofxOpenNIGestureEvent> gestureEvent;
     ofEvent<ofxOpenNIHandEvent> handEvent;
+
+	// Functions to implement interfaces ofBaseVideo and ofxBase3DVideo
+	void close();
+	bool isFrameNew();
+	unsigned char* getPixels();
+	ofPixels& getPixelsRef();
+
+	unsigned char* getDepthPixels();
+	ofFloatPixels& getDistancePixelsRef();
+	float* getDistancePixels();
+
+
+
 
 protected:
 
@@ -409,6 +424,8 @@ private:
 	ofShortPixels* backDepthRawPixels;
 	ofShortPixels* currentDepthRawPixels;
 	ofShortPixels backgroundPixels;
+
+	ofFloatPixels distancePixels;
 
     const XnDepthPixel* backgroundDepthPixels;
 


### PR DESCRIPTION
I suggest that the ofxOpenNI class should inherit from the virtual classes ofBaseVideo and ofxBase3DVideo. This will let other addons and apps easily switch between, for example, ofxKinect and ofxOpenNI, since they both provide the same basic data. For example, on some platforms ofxKinect is much easier to setup, while on other platforms ofxOpenNI might be your choice. If these interfaces are implemented, it is easy to switch between camera backends.

Implementation consists of:
- ofBaseVideo, since the depth cams can supply regular color video. This interface adds
  - getPixels() and getPixelsRef(), which gives data that is already available through getImagePixels()
  - close() and isFrameNew(), which only need to be forwarded to stop() and isNewFrame().
- ofxBase3DVideo, as defined in ofxKinect. This interface adds:
  - The function getDepthPixels() now return unsigned char\* instead of ofPixels&. Use getDepthPixelsRef() to get the ofPixel reference. This will break any apps which already use getDepthPixels, but is should be easy to update them to use getDepthPixelsRef instead.
  - getDepthPixelsTextureReference(), which was already implemented.
  - getDistancePixels(), which is a 2D array of floats. This is used to transfer the depth/distance (in mm) independently of the data type (short) which is used by the backend.
